### PR TITLE
Call unstuck when teleporting out of an engulfer

### DIFF
--- a/src/teleport.c
+++ b/src/teleport.c
@@ -288,9 +288,23 @@ boolean allow_drag;
 	}
 
 	if (u.uswallow) {
-                /* unstuck() calls placebc(), so unplace it here */
-                unplacebc();
+		if (Punished) {
+                    /* unstuck calls placebc() so have to unplace it here,
+                     * though this will not affect the actual final placement of the ball - see below
+                     */
+                    unplacebc();
+                    ball_active = TRUE;
+                    allow_drag = FALSE;
+		}
+
                 unstuck(u.ustuck, u.ustuck->data);
+
+                /* ...and then we have to unplacebc() after this, because unstuck places it where the
+                 * hero is teleporting from. Unplacing it again lets the placebc() below set it properly.
+                 */
+                if (Punished) {
+                    unplacebc();
+                }
 	}
 	if (ball_active) {
 	    if (ball_still_in_range || allow_drag) {

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -244,7 +244,7 @@ boolean allow_drag;
 	}
 
 	/* If they have to move the ball, then drag if allow_drag is true;
-	 * otherwise they are teleporting, so unplacebc().  
+	 * otherwise they are teleporting, so unplacebc().
 	 * If they don't have to move the ball, then always "drag" whether or
 	 * not allow_drag is true, because we are calling that function, not
 	 * to drag, but to move the chain.  *However* there are some dumb
@@ -273,7 +273,6 @@ boolean allow_drag;
 	    }
 	}
 	u.utrap = 0;
-	u.ustuck = 0;
 	u.ux0 = u.ux;
 	u.uy0 = u.uy;
 
@@ -289,13 +288,9 @@ boolean allow_drag;
 	}
 
 	if (u.uswallow) {
-		u.uswldtim = u.uswallow = 0;
-		if (Punished && !ball_active) {
-		    /* ensure ball placement, like unstuck */
-		    ball_active = TRUE;
-		    allow_drag = FALSE;
-		}
-		docrt();
+                /* unstuck() calls placebc(), so unplace it here */
+                unplacebc();
+                unstuck(u.ustuck, u.ustuck->data);
 	}
 	if (ball_active) {
 	    if (ball_still_in_range || allow_drag) {


### PR DESCRIPTION
The existing code for teleporting out of an engulfer is independent of the `unstuck()` function and simply sets u.uswallowed and u.uswldtim to 0. This may be fine in vanilla, but in GruntHack it means that any lingering effects from being engulfed in a monster won't be cleaned up - namely, the suffocation timer from being engulfed in a gelatinous cube will NOT stop, cauing the player to die even though they have teleported out safely.

This changes it to call unstuck() instead, which will take care of this effect and any that might be implemented in the future.